### PR TITLE
[FIX] Layout with a third line of address

### DIFF
--- a/laposte_api/report/colissimo.mako
+++ b/laposte_api/report/colissimo.mako
@@ -88,12 +88,12 @@
 ^FD${a['street']}
 \&${a['street2']}
 \&${a['street3']}^FS
-^FO30,755
+^FO30,780
 ^A0,40
 ^FD${a['zip']} ${a['city']}^FS
 
 /* COLISS RULE Phone+country expediteur si Internationale */
-^FO30,800^FDTEL: ${a['phone']}^FS
+^FO30,825^FDTEL: ${a['phone']}^FS
 ^FO0,950^A0B^FDSPECIFIQUE^FS
 
 /* ||| || |||| */


### PR DESCRIPTION
Without this fix, the "street3" line is overwritten by the zip + city. This PR fixes this, by moving down by 25 the zip + city + tel (it stays in the rectangle with good margins).
